### PR TITLE
Git LFS for Track Images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+static/files/images/tracks/ filter=lfs diff=lfs merge=lfs -text
+static/files/images/tracks filter=lfs diff=lfs merge=lfs -text

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,6 @@
 	path = content/toots
 	url = git@github.com:Brandon-Rozek/website-toots.git
 	branch = main
-[submodule "static/files/images/tracks"]
-	path = static/files/images/tracks
-	url = git@github.com:Brandon-Rozek/website-tracks-photos-v0
-	branch = main
 [submodule "content/observations"]
 	path = content/observations
 	url = git@github.com:Brandon-Rozek/website-observations.git

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+	url = https://git.brandonrozek.com/brozek/website.git/info/lfs

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ git clone --recurse-submodules https://github.com/Brandon-Rozek/website
 ```
 If you don't include `--recurse-submodules` then the theme won't load rendering the site unusable.
 
+This repository uses Git-LFS to store some of the static assets. The git clone process should handle this portion for you, but in case it does not here are the commands to pull the static files manually.
+```bash
+git lfs fetch
+git lfs checkout
+```
+
 Then you need to build the site
 ```bash
 cd website

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_185651794.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_185651794.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bcb8b23aa86e2a475ce2736e279c6c3d556a15b78be9f872e2311f5b6581b24
+size 279274

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_190156956.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_190156956.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:413ec7788b95e7529e61a035081933f41590f83ea166876b4230cb2825485d5c
+size 446645

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_190758001.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_190758001.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55c0934d6fbc15d4d55c046f9a956c997455edd2b84d6b64dbf9490d21ca74a7
+size 473746

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_190929616.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_190929616.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adc339dcad5f04c8b963d4e618eb1e7e1d3537a08c537a57a98f4203c1338f7d
+size 247591

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_191219349.MP.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_191219349.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e44f94037967f34e77f990e1261d4ba38a8386da1935b9055a822f42574dee3c
+size 285199

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_191341985.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_191341985.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7c76fb575e0ffbd2d12bf9b4392e136f7a56cec8db5f74325c8f26564eb15fc
+size 281456

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_192039322.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_192039322.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dfbff2d58a4dfbfe2b9c4e11e0385b90231712dd21fdb6dd556b28a630c3a92
+size 247202

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_192302390.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_192302390.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76ad05b59d39251497ddfca1cd16c1050536bb4ce5fe7cbb2c6f773a87f4a137
+size 266838

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_192340812.MP.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_192340812.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8839c16784a5c7fdce32a2ef09c1df7f9001471a980ec10d36b6e2114a61650c
+size 469513

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_192532792.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_192532792.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfda19ad00df2e0558cccca81bc91a0277a2209856c13142606baf1f9e990a4f
+size 507938

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_192816794.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_192816794.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5acaf1fce028d9706837e4a20ed0a216f7e6b4725d088d9eb5d7fb12026f371e
+size 282287

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_192900773.PORTRAIT.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_192900773.PORTRAIT.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67a2e10b2fe85c5ce2854c63a8e075c62dbb03e59f25c14fdc0a602a79999d71
+size 182499

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_193003713.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_193003713.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6933dd0059e1324332fa2f4a2beaede54c1b6190eeb59a4e02448ec9ef4fb73
+size 290714

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_193127538.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_193127538.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:012fb041712cc6368f21946c62f3de51dd5681533fc34a9307001fbf019bed0d
+size 156762

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_193132425.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_193132425.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f982738cf7fd7be63b84d4ddead030d869e6aa67d0ab0574a1dc067701fe3700
+size 332569

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_193138578.MP.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_193138578.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0444d1e80b23b4806310098f121e1d2d89c4418f645878aa826bdc0b032aa887
+size 280648

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_193947956.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_193947956.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac7072dea2fa9fc953c7ff2826d43dadb0ba5a1b70728ec60f1a9f266b26d324
+size 286983

--- a/static/files/images/tracks/2022-05-18/PXL_20220518_200012681.jpg
+++ b/static/files/images/tracks/2022-05-18/PXL_20220518_200012681.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e7783ab864eea699f3c9106fbf138bcfd0032f89381f9bdebfaeeb487829925
+size 406890

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_200615659.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_200615659.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21862adae6fcdc20bd35c35fc397a79e5887e02d1c494ea377c804013e4e5c05
+size 247310

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_201008987.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_201008987.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39c99b2a2ef0637d2aa6aa416b290d51f68b3cc0ba4e4ee58f90b571ee1a6505
+size 457438

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_201341799.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_201341799.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f22b8a3e8919096b50c61d434781bb2820cbcf384c322ec53719ff545f24bfa5
+size 435275

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_201612366.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_201612366.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d153956820870d917ebee74d8ba144e49781375af61135114ff6e2fc16aec2e
+size 190368

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_201808828.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_201808828.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:818dd24dccd0f78587e7e5eb40059f9577add703fc50e3d319941c0a460f7b6d
+size 197620

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_201831881.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_201831881.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5edb26a2ece7b803b71f750e0159714cf765d015f5889eeecf468e85c0b558d7
+size 125889

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_202858177.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_202858177.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71e88ee3166ea9b63a133374f40f16f6999a4b494ec813a872ae6edba5c0d061
+size 305525

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_202906658.MP.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_202906658.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:277f389f748c4d76add8ac9cd544c7afa4af63de70c2794a49740bd57f999ab7
+size 230565

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_203405335.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_203405335.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef24431a1405c4fd27a5a41ce12fe79ee1cfef49609be492fae6fec70aed9765
+size 197939

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_203408972.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_203408972.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fad439912863c276f56390a5c44020283d992394c6a7ff09a95b450c2a0849c3
+size 521104

--- a/static/files/images/tracks/2022-05-28/PXL_20220528_203452432.jpg
+++ b/static/files/images/tracks/2022-05-28/PXL_20220528_203452432.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b4c740bff9938a86b870b246e00e7864f100d9d23707e39430202112d869a5a
+size 187632

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_143720955.PORTRAIT.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_143720955.PORTRAIT.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d607dabf4666e2b0f9f3149b1113f475c43126ee900642960e219c096fa3b588
+size 288654

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_143833620.MP.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_143833620.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:775945f79f81c9199b7593054f5c61a01d793495f41d631e69629a3b4e468fc1
+size 312540

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_143853936.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_143853936.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abdbf8b63a8457332bb9e4a9aa4edc14ed8c9fcbf1bddca34e7333714076be63
+size 310829

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_144934389.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_144934389.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fab0fb384ad8b84aff5fe8631a386521d9f74ff1cdef1d779cb3071c266258f4
+size 268950

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_145118197.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_145118197.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdba752b143567a211799eca08ea2c7569331f0b7ee2ad64ed35d1fcabda5eab
+size 284029

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_145437829.MP.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_145437829.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6194d9bba7c3297ff087685714940a307ddc7dfe1828360dbbed9ab47f0b086
+size 244929

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_145848900.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_145848900.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a736f92f901dbdb4efbfa78228c020e727c499b310d3b931675f638b906ed549
+size 226664

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_150250788.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_150250788.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:610157945a434e3eb082093d698e6766520e9e7b9b4cc7fecded9590bf75ec57
+size 313242

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_150317244.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_150317244.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e39bcd1ef2cc5c9205bbcdc44b71a9479194491eac1fd7ee6a46e89e09424d83
+size 218204

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_150847633.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_150847633.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1cfff8596251e953c4766f9dfdf79eba190ebcf4f16dab4176f26e8ee4afc4e
+size 278505

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_151848805.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_151848805.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27cffb9a05776ebd97ad2ad3f0209258b2c18e9683c96b460c52fe413005c996
+size 472136

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_152229241.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_152229241.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:198657cccdfdc56588be0d56164eae62c0d2d58dfd62da67170d5555301e8a25
+size 240042

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_153155282.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_153155282.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba257c56d5f1d7bcaaaa9423c62c23d7ef844f26818627637820a9f50b468b69
+size 150401

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_153200382.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_153200382.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e81a55e539bd514f426fb0df53fe762de5f70bcabb240a74873c1a77008885f
+size 237947

--- a/static/files/images/tracks/2022-05-29/PXL_20220529_153321957.PORTRAIT.jpg
+++ b/static/files/images/tracks/2022-05-29/PXL_20220529_153321957.PORTRAIT.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33f26daad19d04bb232aa0f80f4147768aa82e8b3bbabc1f1c2f6e203c60a0e8
+size 160142

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_141649331.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_141649331.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:324b2b83a7dcfee4b47eafc53365960cb13e2324b7f64e7a5d91b022d658e6ca
+size 131582

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_142555170.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_142555170.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69e1ecb555968b7199c7eaa19962501f5b0c8a1cb820d7560cb30a8504c53797
+size 305197

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_142637549.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_142637549.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:210c967775bca718e6dd3f22717487f1d772faa1533004430b089688cf95db5a
+size 269951

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_142814350.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_142814350.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:739d5874670d2d85135fe8ce7d36a07fb39015aaad32a4a9750825c37d2b6546
+size 240323

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_143205105.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_143205105.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0fe7712945f8505e90108fd04b50c18ea5c4b7f0ee99ba3bb32f880f667a980
+size 310328

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_143218068.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_143218068.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d81a9518016a9cd4644181c55d664a33bb51a9ea62f06284699f408eca2d4db
+size 258660

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_143903189.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_143903189.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98b063eba1841f2c26c6d0fde7a6573bb51980b7024cb91b7fd45a5033f65d00
+size 188629

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_144416173.MP.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_144416173.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:925670a69efbe4201f085a084364b44fcf63489896f6e62811def9aa19c48068
+size 423364

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_144700467.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_144700467.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cbdf8fef34fd808d62e1b87a39b89b1c8cbb12dc004c18e4df990a9f5a836b7
+size 277266

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_150316229.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_150316229.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcb44330c396e6a8bd46510f18f300c6b7436724944fe86bd7302fe46c5cbaae
+size 117920

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_151222080.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_151222080.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a61aabd7bf09fec841807ebb0895a9a705d8e9b7653b9c18da6bb8096a6894b
+size 244387

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_151610481.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_151610481.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab619d546faf171853dadd50e156d8d3158525e1943927f6207284000fb1bfea
+size 277493

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_151724547.MP.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_151724547.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:692df05bd05adcd2dc146bfcb63613d35f2f81098dc9a29e48cfa8214db5361c
+size 469119

--- a/static/files/images/tracks/2022-06-05/PXL_20220605_151916080.jpg
+++ b/static/files/images/tracks/2022-06-05/PXL_20220605_151916080.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fc0f0b1a8d0c6b26e06a7bc3a4996ec150b53a074808eea27b353ae20c73605
+size 299144

--- a/static/files/images/tracks/2022-06-10/PXL_20220610_234324357.jpg
+++ b/static/files/images/tracks/2022-06-10/PXL_20220610_234324357.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5075dec93dfaf9791b6bc5c91c6a00604344eb2a5107b83543537f624fb10906
+size 267857

--- a/static/files/images/tracks/2022-06-10/PXL_20220610_234327983.jpg
+++ b/static/files/images/tracks/2022-06-10/PXL_20220610_234327983.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ef92d2c0e436e5173064d094f6494e65cb5c56b040c869076eb859ca658c61b
+size 235978

--- a/static/files/images/tracks/2022-06-10/PXL_20220610_235239145.jpg
+++ b/static/files/images/tracks/2022-06-10/PXL_20220610_235239145.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:965f863bdbcc17703b6fe5b0e2041ffb7d506a4f48fb80eb740d22860c93f983
+size 126442

--- a/static/files/images/tracks/2022-06-10/PXL_20220611_000911957.jpg
+++ b/static/files/images/tracks/2022-06-10/PXL_20220611_000911957.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7aa2898384821611ed0724164001582a732cce4a02a51a2a8cc546df77a0e68e
+size 331743

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_152740123.MP.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_152740123.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68392f2adf9c1af2108cd7114d258227742724727e63bbdc5a9aad1ae13a79b4
+size 248951

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_153032574.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_153032574.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e392469278107db921a11f4b8243b75ba5d9f9c75bdd7acde5e5c623a0b1d3c6
+size 136156

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_153214533.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_153214533.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bcc9ca9ffdcc8ce91728d52a8b5b23815d5fc5848d194cd6bbb2f5ca9b66a5c
+size 193903

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_153321755.MP.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_153321755.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c70d8a15507528d666230fdb816644d96e683209e9a5c524d9bcf38bcbb14d51
+size 248106

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_154129931.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_154129931.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96936501577b822f62bca3f44e8e03b25f035952d5e1b80e58cc452b20056350
+size 285822

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_154457453.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_154457453.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e28806bbfe239ad061e5c7dc28b4993693a4be001ee069322a42234fd3698c4
+size 280013

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_155243636.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_155243636.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dafedf0427afb810c2eeea53413cc177f810371890c855dd0591e93f17245c62
+size 118939

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_155253642.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_155253642.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9e604d874a1da91c593d028b959439ce60fe3e596137db033e6fe2b3486940f
+size 90141

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_155329984.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_155329984.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81aa3269194c14308663855f934f6453708cd1beb9eeea9b7db58b436640c9c6
+size 333867

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_155344685.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_155344685.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58f98b7cb17ad5e7a353738bfa696915301036a5599ec25650a814c88bca7231
+size 107246

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_155409613.PORTRAIT.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_155409613.PORTRAIT.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:054c12eb663064e3b0a083bfaa4c99e1f170c9b0d9ef00245b3c91d57d171a17
+size 204089

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_155443341.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_155443341.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a152750830053f35ec03cf21994ab06a411246ade16d6b6bee9eea033ff12854
+size 98391

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_155538561.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_155538561.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f94bd4ce2d471172979ba73278ab537e72a55d81b380b7c1dc242f1fce36e963
+size 97844

--- a/static/files/images/tracks/2022-06-11/PXL_20220611_160145013.jpg
+++ b/static/files/images/tracks/2022-06-11/PXL_20220611_160145013.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b409a9b7426b96d27ec540b57948c2008aff12b447980b04613cd1df795335b
+size 230239

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_172955526.MP.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_172955526.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce0e08c266f9c73093f2a8f73d03af23d7905689b866417c09b8651685887965
+size 280210

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_173316792.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_173316792.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c097daaaf103d0ca833099344094f6094cab74a40fc42871d04e9dc235e3dbc8
+size 189150

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_173437686.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_173437686.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d484fbdfa3156b5972bbf8c7ea81403f45f042785675b99de4794211890fa51
+size 250189

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_174018046.MP.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_174018046.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61df7988983c81381e21aced3c9f21f6a4ed723c743d8fc4b455845350177127
+size 391273

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_174050619.MP.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_174050619.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d5c0fefc2ef6aa9649c9c8d86206ab6c080e89bf94f3bca684756edb50411fb
+size 201098

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_174106957.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_174106957.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4f3d2125de7b2e04bf6bd05f6a33d2ab958273d506cef539bad2d2341b42438
+size 207149

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_174157977.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_174157977.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f51fc5e1f0a50e90fdbff88ac33117b51886c25c8c1b51266dc2418ad27ff66
+size 290834

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_174228131.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_174228131.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be4c3dd50565eff72efad81f2752e58b2ffa9f49b49711b14396853416dd82ed
+size 205955

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_174532132.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_174532132.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6276b9abfc97d5c7ae0f2a96a068a09f4c384a6e54311dfe59dfb6d10524f3c1
+size 244597

--- a/static/files/images/tracks/2022-06-12/PXL_20220612_175347803.MP.jpg
+++ b/static/files/images/tracks/2022-06-12/PXL_20220612_175347803.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7194ccbf233d36f3653d15e5ab443faf1fb8f3222a9d028c3faf8429c24488bc
+size 414709

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_161731004.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_161731004.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0639b981dd0ba94e62a0ce3d147a403827d492c7ffa24632efb8c23766b05a6
+size 369513

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_162136415.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_162136415.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:311d36cb08cd446356585bf7a78cd840ffdf6adc688fa4e855d1cde220e424b7
+size 487040

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_162449910.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_162449910.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27c6393d7e8ef30bffea64e906b8fcfb144a9a87a234054d726750384676f1d6
+size 463755

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_162505955.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_162505955.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:684a222f736cabc1bc8eaa7d70d32b3021350831b75695c4218a2bd9e5937abc
+size 264389

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_162518138.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_162518138.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52021dad80b5937a2cbd1c0d3fc3dca41a9566de6ef1507b60bba6916ff20c87
+size 270436

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_162857372.MP.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_162857372.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb94b7af12822aa5fe46b3ec7dfb8e7cc0de623644247a9f50c3c4110d70c82b
+size 454339

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_162959096.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_162959096.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa3b20226c1cbedf47cff8ced40580a17c092d8ee66d5538191545f0f3e493e8
+size 253979

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_163232712.MP.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_163232712.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c5795c761b48e2e799e102ffa946f832bce3e00b687ebe40aebca6f3d70a2d8
+size 475432

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_163616323.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_163616323.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2df456863600c884be1f46cd6ba891ad2b3365f1c856df23a6d5c3ca3a24cd4f
+size 491559

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_163701651.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_163701651.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9766b7f0ac1518c91a6f72f61a488790893a2dbf170893a363218cd0b2eab725
+size 202801

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_164614488.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_164614488.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56dc86856007f9a5de2f9b933f09d50ee5e246f7938f387284c6c8d7d5c64cc0
+size 294944

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_165302653.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_165302653.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c49a828e410eaef7886208a0f90c2945e58220dd67e8afc9375647481875a5c
+size 283659

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_165331647.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_165331647.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6d3b44fe21d40e00de50dae9b967e9652e42044824180bfb3752da362cf7e5c
+size 503431

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_171248248.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_171248248.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed090cc3bdd86b007ebf5b64ece9dbce0232ee104b0e6580898dfa16c0bbad17
+size 537576

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_171634378.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_171634378.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d2a683e2babd5fee4bc5a10e06245189ba3f81445f92b08b0937025f50a3a21
+size 324888

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_171804950.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_171804950.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c00474ecc2c2f34ac9639da47e0d1fa1d7592cf4f6a96fbef2b196e8c2a6cd89
+size 520315

--- a/static/files/images/tracks/2022-06-18/PXL_20220618_174707317.jpg
+++ b/static/files/images/tracks/2022-06-18/PXL_20220618_174707317.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0fef97358f2a3c09df57e08bb1118455b464e141e96e3fa464bae67fdb0483e
+size 294064

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_135000070.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_135000070.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb08547598cbbd5649e4f71e7e76fe370323e85ff924e2201f88c638b83fe3c1
+size 279736

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_135937862.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_135937862.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d35b34195082f8a6a8fe92d68de58a572c64d8431392a84b65e9917b79455034
+size 186977

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_140703665.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_140703665.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da692355ad1ad5972c35c0f18d9a6dae8165453dae3f221cdc25b6c6401ebb5f
+size 276412

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_140722360.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_140722360.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21ec2305d711194da2389efb89a1acf86eb0f8d2667b590a02f77c3819f38467
+size 251213

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_140950974.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_140950974.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9da0f1960073e99926556e2868cb4a7d2c8c99cc9d0581d36a5a7d22cbf7c309
+size 253624

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_141057885.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_141057885.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd0622d249babb8a00fe4249109f9265bcf028176ea32a434216e65011b71435
+size 310055

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_141200473.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_141200473.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7c71cbc568b43fd2541051061b70cf0b56a9f25df132c7237f45caf1af2da25
+size 452264

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_141355108.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_141355108.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0b418a232d2d1ae4b7a9fb73908432fbc2024b7703ee65d054bcb5a3ef7b401
+size 112030

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_141531172_exported_33_1655668140292.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_141531172_exported_33_1655668140292.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f9de5152e67acdf5febbf09e188a3c80a6a271fee040e377f69650e1699350b
+size 72519

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_142004443.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_142004443.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:264befbebcb61841afeeb2827d9db555c7fa02cbfa619544df7c84fc047672b7
+size 194318

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_142412610.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_142412610.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0def2053dc98dc3b1c9a56e68ce772ea697366bb5feb6189de935e5a03184b43
+size 355867

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_142450354_exported_33_1655668026087.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_142450354_exported_33_1655668026087.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0f70102305c2ad76006f9cdc32d10bb3107140c3b42abf6b41dcbeddaf6de39
+size 138014

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_142500088.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_142500088.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0489e3a373212afcb7dfa421e689922bf7b9ab3b856387c0dac476b90220a6a0
+size 374992

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_142746391.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_142746391.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f881dca92feab67682621b7e1d6d2ee70d056f01c9386d9deb630a3ce519f01
+size 452700

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_142852203.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_142852203.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff7e17470f92fbab9a548828b181dfba29b738e624287a0f89a1da094dadc5a2
+size 264858

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_142909537.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_142909537.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b7a68e5520d414364c0d92c31bc9091fe57a9a1c4413245a009da0a87bfa8f1
+size 444124

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_143154452.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_143154452.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55227013040e9f6d04c1ee46772d54287b60b3a790a03adce1381d49e9286ea7
+size 271971

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_143228977.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_143228977.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a1286dd9819bee784afaaec3ab60a9c0b444580441e9444b66850a7106ca87e
+size 196657

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_143308072.MP.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_143308072.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7f01d0b2daed1dc4f520e6b64a38dad41254bb5eba8f03b44e0d8bfc2036f86
+size 210298

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_143443085.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_143443085.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8176c0f9ccbde17dc2948ce3cde242d4ce7a34212638c165a770060f6513a6f
+size 406344

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_144112787.MP.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_144112787.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f1df4b96561979ec486af9d207252cc2295723b66c600bec862590a2b112ade
+size 229329

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_150026181.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_150026181.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a0969b649e34d69e329ed738fdc10334ba241c2f87cd558e013ad78d36b3d1e
+size 421363

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_150328134.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_150328134.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dd9508e3906053e55172a3abdda3a0f5bdf21d5ddcc99f085f6f50980f8a0bf
+size 465338

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_150356018_exported_66_1655667817716.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_150356018_exported_66_1655667817716.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47d2471ba53b07633f1422a92026bb7dc2250f71cebed2ebc9fa5b0cfdabada9
+size 115699

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_150607431.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_150607431.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a955b4ecdbcd1440f4d71fad9a769ff5e42dc736511b519cc5099828eed03a1b
+size 154389

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_150801260.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_150801260.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e87060cb0d79950c3d33613ba11c0a78a88947d7264e76cd56ee73a58da108b
+size 227023

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_150916144.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_150916144.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe03dcdd0e470be35cd71cecdbd09d7cfd63fa96df4f020c132d19c6566039f2
+size 160768

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_151437187.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_151437187.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0222be0d341f35fa150d28e0df48291fc203aeb956380f91c9ba0d3ec826cde7
+size 438192

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_151547059_exported_266_1655667720734.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_151547059_exported_266_1655667720734.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45b34533892aa96c5081e571228c342569c8fc9dc8aa21f6cb779845187c04e0
+size 445385

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_151640416.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_151640416.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a71362aa1bbd3468c1c59eda1dceb4b8efc27aded81f48efa264206c6b23053b
+size 259757

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_151820147.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_151820147.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3408665e4c9bdc765251b1d2c842c4ca11382ada37f6ed0121dbeacee461356d
+size 250741

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_151945290-PANO.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_151945290-PANO.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b38078e29c0b36cd0b7684b1481fc6bfd4eb2091efe497f7515a3a292fdf4d1
+size 66992

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_152132731.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_152132731.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e73ea5609b8c4bdd331727c1aeba23adc72097f674ad0de4b02c0b474faadc9
+size 118707

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_153022213.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_153022213.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce07ece9b7016b84b68c23822bba32e5d60be2d386981655d6d4788a75af9f50
+size 318900

--- a/static/files/images/tracks/2022-06-19/PXL_20220619_153151477.jpg
+++ b/static/files/images/tracks/2022-06-19/PXL_20220619_153151477.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0031b96bd0780a50aadebd1ad0e10d56267a15a277401d9097ac915f5154ff3
+size 123212

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_182051407.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_182051407.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b62d5762fc71d7a2b75455f2ed1287478ba111234e24a2ab4ca76f511caf492
+size 119261

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_182203108.MP.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_182203108.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aaf92f42fe07657676c57152ab68d89cfd856b293166cca77efea29c73e859e5
+size 135149

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_182925937.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_182925937.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66684682d2951b4c682599a4024abfed7dedccb2aefc7bf117990ed556a29a38
+size 297626

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_183328431.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_183328431.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d67bbd7dedf8a0af9b995b7dbfa4a74848e92162e22e6550b655b195e67ddcd
+size 198831

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_183340368_exported_1132_1656807019031.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_183340368_exported_1132_1656807019031.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfd0c19eef44b8d7d0b7a35e7f062d044c91129e6bf830424c725665136a4538
+size 104030

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_183452281.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_183452281.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdebc859cfaab5b76130e70304221f0c43bb1aa7f856e7c602f392aa6f6d7c5c
+size 244184

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_183857570.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_183857570.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e36be8503a2cda76581301aa16832d0883c68da87bc6662df633a033a54f90e
+size 243121

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_183905251.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_183905251.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:898664e329234789b95829c1ac7539e78e298986d2ba2cf017c020dd3b62337b
+size 224641

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_184055390.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_184055390.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a350fbf41049f001af0ada40bb51358a3918965799ce1e299fd188a25d7f7fa8
+size 308233

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_184322134.MP.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_184322134.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74e9a42dcda2b9c957ab3f9010759859da97fb15c3d8f96007ca9ecfe6e785d1
+size 205319

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_184329813.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_184329813.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:577079a729c68e793f4703d275d38d6906182bcc17e43f2f40439bd2e4264ef5
+size 367336

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_184942321.MP.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_184942321.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6a2343453147ae58722dc28ba7ddefd34162827b4e7fcb87dc8fffa64429945
+size 389061

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_190906324.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_190906324.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6793c6890bae4fe1665a91a0d6983ba51f0c2e19d37d3d2a94495ac4718f5aab
+size 204769

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_190915986.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_190915986.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d4d200ebc574eba733b3a83ecffef2a4530406e2479ce8e8d8c92dff027d6eb
+size 156325

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_192626217.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_192626217.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bb4a6dc90f3f7b09cb56c91c86d3f6dd3b6a88e17373184a7414d4afa3e4dc3
+size 345493

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_195124386.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_195124386.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33e11238c7995b2efebc1db6e17fc739e5e91a11fe72069d1f4fe9af5b7a8e35
+size 151604

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_195238699.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_195238699.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c552bbc881d88ed44220b556808d1206b80eb06e6d807e0448022458ebb4b0a
+size 159044

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_195241156.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_195241156.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a82a6e72ae193ebd3f9eb0f477f00a5cb5dce08750c918fd41a9de92fc53ecd7
+size 147894

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_195356778.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_195356778.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29dcfd42666d162140668f927fc739e56b715d1467c041069c6ba5c58fe88c94
+size 87172

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_195450041.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_195450041.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ffa05a57ed24cce28ffbad33da87d69f08ea7c268ec45011af84aaf347c2499
+size 215712

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_195744514.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_195744514.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78e55f33f91620cdff4483710595cfafebf1ad6d7d2ad548f4f98bdb721ca2ac
+size 145829

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_204232224.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_204232224.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f6f3cb7cf582794269bd4cbbbeea9e3f6b16784040abf51cf616b4c04401a4a
+size 228665

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_205157067_exported_932_1656806487103.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_205157067_exported_932_1656806487103.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90587f8b2bc58eddf2926b514a6bacf24ffa83ecff4993c5b25446fc38537d32
+size 149943

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_205202829.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_205202829.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0e91f21eb63af0a0bc72c1d31ce4d1e80dcf2fca92db5a2ccc2c84f7437f8b9
+size 297608

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_205920316.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_205920316.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d8458c7bb3126c7e4719f8f469c41c895d8cfdc7c13cbeb6461d6b24dc5027c
+size 320089

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_210141792.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_210141792.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c8765dba805a7169e8926c5b9810d6bed10a8d9edfb22fedb76776c4f111ff9
+size 407332

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_210205575_exported_100_1656806462923.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_210205575_exported_100_1656806462923.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aebe88d415681d564f1dbfd1b43f996b327d04056378051d04540868e2f7bf6e
+size 75596

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_210258906.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_210258906.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:931e5531b1556a992eab7abe87dc54de815e77c686fa227b4efd7754952972eb
+size 206477

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_210338993_exported_399_1656806448177.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_210338993_exported_399_1656806448177.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e839f962753ce3faa8429573e99ce9114f16b69fa6655492cac7691820f135c
+size 97064

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_210538891.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_210538891.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67da1a1556144dc7e3531dd56aafb6a18df2ecb22249035371f507f625752aac
+size 92410

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_210902688.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_210902688.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f03b38ec2576634033bf125fac0de0c91d491d4fd8e1eb87f4edc0e8f3cd37f
+size 398065

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_211519638.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_211519638.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4aa948e23b4ce314df335abf7943d37009053d60e00e5ee115a2fd464e7c217d
+size 372476

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_212004925.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_212004925.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96c3af83302a75cf609da35b3dcc75d0cb6b69992e70d08880824432537321ec
+size 363051

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_215131505.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_215131505.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86838010a721e06fb17bb73cbe0fcc24717e5212659907ff13f32e840763f429
+size 143653

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_220433235.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_220433235.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:704042a3f10f648a7c02910a66ebd927d6765dac3a65892f19fa451b25170baf
+size 223558

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_220559204_exported_732_1656806306094.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_220559204_exported_732_1656806306094.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64ecfc862617121566cb334eb416a4f966b4cbc13edd7ed53043e8eef42c4b00
+size 78721

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_220708065.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_220708065.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0782a33ae274e112d1d4d604cae6e3b7f8d5d7f8f2eb2b72326e43b0558d7e03
+size 125281

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_221420858.MP.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_221420858.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d23ba040134dfe4c31150c439259799e861b6480845ab7c41410f483c7749bd2
+size 181389

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_221515348_exported_799_1656806269626.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_221515348_exported_799_1656806269626.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba5ff87e061d3348ac5f09dc29fa875f740b3858962c168e97dba46c8f1954fa
+size 165603

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_221815836.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_221815836.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84afbc5bbfc168d2cc32c3ad94bcd4022acfa9eced9fee442f512596723db3b
+size 285147

--- a/static/files/images/tracks/2022-07-02/PXL_20220702_222556327.jpg
+++ b/static/files/images/tracks/2022-07-02/PXL_20220702_222556327.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f43e2b1bd618bedc960895999bbafcbb1d3e6e81f1e8f502e131f55d8ecadd5
+size 236806

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_192855283.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_192855283.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb2ec224ecae137d97ed9b0dd76598d2f7cd551604288c394db9a37033dd88de
+size 275813

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_192900233.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_192900233.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c0cc7c821153ff271ef6e3fc48f0e34709fd657c03309f73b1824e9a2f23157
+size 360806

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_193037865.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_193037865.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73b0699e0902b06626f6003d9d5fd77ecfaec6b526c75431908721009fe381c0
+size 298712

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_193040244.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_193040244.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da60be30a9fd6f0279bd2f06bbeaa252e05959f5202589b463916a3560395d88
+size 542532

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_193857117.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_193857117.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06c4dd4c3b08f499ee0b4a5ba68373120867b8eae7958b4bc6d4920f2801126b
+size 268401

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_194510979.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_194510979.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9eb47da245a2ca055f763b2cd46f5b393034701c2c033a5d3d91a54f267be02
+size 457899

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_194556936.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_194556936.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b288aeb12f9ce89685792f6e8386a0851822e2e65a153594bf1f9a517fccfb20
+size 417615

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_200254253.MP.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_200254253.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77dafa1d686f294989aa857b2a39f2f76306b2fd26e9cccb707b7f0cc8b2f185
+size 470740

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_200342514.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_200342514.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:542c2269fadfbc0a32fedd2abda7f4e977c4b240fc6e0d4ccc6e67aae6cf290f
+size 253775

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_200431012.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_200431012.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d254bd0876a21addb2b8f2be24cbe75cabb38e08074d2c361c076a64f2bf6c02
+size 272209

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_200440404.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_200440404.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b46aa13502b03d166a62766eb7bc2c2d8b87a6dc471374e2850141cb12d65c67
+size 249345

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_201336997.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_201336997.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0754f56c5979a705ce1d77794d0a21adbe9438351e199aebff411e369e2feba3
+size 269523

--- a/static/files/images/tracks/2023-04-22/PXL_20230422_204415462.jpg
+++ b/static/files/images/tracks/2023-04-22/PXL_20230422_204415462.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aeeb4812a1acac880e27131d826d9b15cd99c1876bcea45af469f64a24aebd19
+size 353809

--- a/static/files/images/tracks/2023-08-13/PXL_20230813_163601629.jpg
+++ b/static/files/images/tracks/2023-08-13/PXL_20230813_163601629.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3667411633316330e5cd02d837ced13b97051cacc65cf6ba0aad809a605926cc
+size 516302

--- a/static/files/images/tracks/2023-08-13/PXL_20230813_163940124.jpg
+++ b/static/files/images/tracks/2023-08-13/PXL_20230813_163940124.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68afb0c71fd72c30254772c651f5b64a237dacea2a61635e67e13ab8f4483b25
+size 614209

--- a/static/files/images/tracks/2023-08-13/PXL_20230813_164419717.jpg
+++ b/static/files/images/tracks/2023-08-13/PXL_20230813_164419717.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f8d02b8ec577b024b2b34d4d73bbd2ccc9e51f7095ceb527a27096055b35818
+size 223742

--- a/static/files/images/tracks/2023-08-13/PXL_20230813_164457871.jpg
+++ b/static/files/images/tracks/2023-08-13/PXL_20230813_164457871.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7034aff91a7a2896fcf45734e12bffa8e54801f88f4a62e61de0603156805d7
+size 494082

--- a/static/files/images/tracks/2023-08-13/PXL_20230813_164804999.jpg
+++ b/static/files/images/tracks/2023-08-13/PXL_20230813_164804999.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:655809f77d9ef864325a641e46d1a4117d1b06ab8d7ff7bc30c406b522523bf4
+size 226018

--- a/static/files/images/tracks/2023-08-13/PXL_20230813_164841269.jpg
+++ b/static/files/images/tracks/2023-08-13/PXL_20230813_164841269.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54dd5430a20c20deeaad84e54f3161229de20687556fabeb0a991f0ee3ed6fb3
+size 260642

--- a/static/files/images/tracks/2023-08-13/PXL_20230813_165155198~2.jpg
+++ b/static/files/images/tracks/2023-08-13/PXL_20230813_165155198~2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcf00babfc9d249be0e0835650ff2c0b6950a2175c1386de49f35eafc97ce29f
+size 347502

--- a/static/files/images/tracks/2023-08-13/PXL_20230813_172151573.jpg
+++ b/static/files/images/tracks/2023-08-13/PXL_20230813_172151573.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed8c9a11adac28f0e1ab9fd64bdecdeb70487184beb2033b899c66aba4ca9e60
+size 203607

--- a/static/files/images/tracks/2023-08-13/PXL_20230813_172201629.jpg
+++ b/static/files/images/tracks/2023-08-13/PXL_20230813_172201629.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:750d45d9cb097a91da7a148ee6c74a91a88b79cd2458384ac2274b75bcd470ea
+size 236029

--- a/static/files/images/tracks/2024-02-03/PXL_20240203_193011304.jpg
+++ b/static/files/images/tracks/2024-02-03/PXL_20240203_193011304.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d148ec37bf7019b71110f474f888bec3473f264656794c2f1ef28d7d6f77a1bf
+size 246073

--- a/static/files/images/tracks/2024-02-03/PXL_20240203_193544536.jpg
+++ b/static/files/images/tracks/2024-02-03/PXL_20240203_193544536.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:674ac045492607c25caf8bae8121ccefabb075f7b0c7d988517a134fffbb5bc7
+size 147231

--- a/static/files/images/tracks/2024-02-03/PXL_20240203_194505932.jpg
+++ b/static/files/images/tracks/2024-02-03/PXL_20240203_194505932.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7fbab91e80f4b101ee0ebc597a84448d7c5f28c1d772719894cd1dd5e852e48
+size 272008

--- a/static/files/images/tracks/2024-02-03/PXL_20240203_195428848.jpg
+++ b/static/files/images/tracks/2024-02-03/PXL_20240203_195428848.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57a3db4d10f74145dc8cdd4f20c7381016ec568aa4ff648a342c11b37f8643ec
+size 271998

--- a/static/files/images/tracks/2024-02-03/PXL_20240203_200435261.jpg
+++ b/static/files/images/tracks/2024-02-03/PXL_20240203_200435261.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dac6ce8b826599ee8f24464b0e894c53816afc14598569979bd42ac3b21321c
+size 282737

--- a/static/files/images/tracks/2024-02-03/PXL_20240203_200934099.MP.jpg
+++ b/static/files/images/tracks/2024-02-03/PXL_20240203_200934099.MP.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deb3a341821093807bb7c278dba3df76063db786f0d3bbc12491ad3914a18729
+size 407699

--- a/static/files/images/tracks/2024-02-03/PXL_20240203_201006353.jpg
+++ b/static/files/images/tracks/2024-02-03/PXL_20240203_201006353.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a408f832eaea423171ba1af9ce0849c7bb6b0fa9d10cd9a1fe9b7b15f1db821
+size 463528

--- a/static/files/images/tracks/2024-02-03/PXL_20240203_203342143.jpg
+++ b/static/files/images/tracks/2024-02-03/PXL_20240203_203342143.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc0fa6d3420a321d1754a7b696914235d7ed6526993af58bee6ab9a249aa6f25
+size 199106

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_221029525.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_221029525.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74eace15ff94fbb232128108d90dc0861ae8aa5e66464c28671247c5cf4e6595
+size 235711

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_221337864.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_221337864.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:676358b45aac091232f35310162a257ccb77df8cc69e3b304c845d1a2be750d5
+size 331545

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_222623565.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_222623565.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75e69f4ef8667cd4b3e5eb978389406680d9b31fe80be16d3444fc440d1c7610
+size 163347

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_223846882.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_223846882.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c56d819525406890bd5464fc0c666c71ef750f1c271828d0a3c7a74a7413d4b
+size 215644

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_223856913.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_223856913.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:108f5457dabf5deb4789f1712e2cccd3606ea83a10108d9e12d11510dd3def58
+size 113399

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_224018725.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_224018725.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17a975f4fd683f2bcdba259aa039dc3a90f9b831b311ea8a58b9401615f52f23
+size 528736

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_224244889.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_224244889.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e061ddf1d05824f1e98f0b1688d829f4a0f2475df6ff8abdd3940f310259a61
+size 205797

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_224401629.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_224401629.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5726f1badb8a4603c159846ca2065bcc0c8e1df1c7d12fe39a154bf4fbe6f23c
+size 184160

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_224501345.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_224501345.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:332aa6f9cb4fac76834cdb7df99f16b7deb42e6ca2341d1c454928e359cb0486
+size 180820

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_230834922.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_230834922.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2100a175cd3e3dd067613b5ccfd71ad4f2e324abbac68176dc9b0752cb0c31c4
+size 474135

--- a/static/files/images/tracks/2024-07-27/PXL_20240727_231528504.jpg
+++ b/static/files/images/tracks/2024-07-27/PXL_20240727_231528504.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3e7ca93e6ec519e50feb021e5877179174070ad6933e8f1b44599aa3a926799
+size 264501


### PR DESCRIPTION
Instead of using a git submodule, use Git LFS pointing to a custom Forgejo instance